### PR TITLE
Optocoupler

### DIFF
--- a/lib/Opto/opto.c
+++ b/lib/Opto/opto.c
@@ -7,44 +7,49 @@
 
 #define TIME_LENGTH sizeof(uint16_t)
 
-static uint16_t previous_edge, current_edge, overflow_count;
+static uint16_t previous_edge, current_edge;//, overflow_count;
 static unsigned long delta_tick;
 
 static uint16_t previous_tick;
-static unsigned char overflowed;
+// static unsigned char overflowed;
 
-char check_overflow(void);
-unsigned long overflow_ticks(char);
+// char check_overflow(void);
+// unsigned long overflow_ticks(char);
 
 void opto_init(void)
 {
+  TCCR1A = 0x00; // pure ticks counter
+  TCCR1B = 0xC5;
+
   previous_edge = ICR1;
   previous_tick = TCNT1;
-  overflow_count = 0;
-  overflowed = 0;
+  // overflow_count = 0;
+  // overflowed = 0;
   delta_tick = 0;
 }
 
 unsigned long get_delta_ticks(void)
 {
-  check_overflow();
+  // check_overflow();
 
   if (ICR1 != previous_edge)
   { // There has been a new
     // obstruction
     current_edge = ICR1;
 
-    if (current_edge > previous_edge)
-    {
-      delta_tick = (unsigned long)(current_edge - previous_edge + overflow_ticks(0));
-    }
-    else
-    {
-      delta_tick =
-          (unsigned long)(current_edge + (pow(2, 16) - previous_edge) + overflow_ticks(-1));
-    }
+    // if (current_edge > previous_edge)
+    // {
+    //   delta_tick = (unsigned long)(current_edge - previous_edge + overflow_ticks(0));
+    // }
+    // else
+    // {
+    //   delta_tick =
+    //       (unsigned long)(current_edge + (pow(2, 16) - previous_edge) + overflow_ticks(-1));
+    // }
 
-    overflow_count = 0;
+    delta_tick = current_edge-previous_edge;
+
+    // overflow_count = 0;
     previous_edge = current_edge;
 
     // return delta_tick / (F_CPU / 1000);
@@ -60,35 +65,34 @@ float get_delta_time(void){
   return 0;
 }
 
-unsigned long overflow_ticks(char delta) { 
-  unsigned long cnt;
-  if (delta < 0 && abs(delta) > overflow_count)
-    cnt = 0;
-  else
-    cnt = overflow_count+delta;
-  return cnt * pow(2,16);
+// unsigned long overflow_ticks(char delta) { 
+//   unsigned long cnt;
+//   if (delta < 0 && abs(delta) > overflow_count)
+//     cnt = 0;
+//   else
+//     cnt = overflow_count+delta;
+//   return cnt * pow(2,16);
+// }
 
-}
-
-char check_overflow(void)
-{
-  // printf("%u : %u\n", TCNT1, previous_tick);
-  if (TCNT1 < previous_tick)
-  {
-    if (!overflowed)
-    {
-      overflow_count++;
-      overflowed++;
-      return 1;
-    }
-  }
-  else
-  {
-    if (overflowed)
-    {
-      overflowed = 0;
-    }
-  }
-  previous_tick = TCNT1;
-  return 0;
-}
+// char check_overflow(void)
+// {
+//   // printf("%u : %u\n", TCNT1, previous_tick);
+//   if (TCNT1 < previous_tick)
+//   {
+//     if (!overflowed)
+//     {
+//       overflow_count++;
+//       overflowed++;
+//       return 1;
+//     }
+//   }
+//   else
+//   {
+//     if (overflowed)
+//     {
+//       overflowed = 0;
+//     }
+//   }
+//   previous_tick = TCNT1;
+//   return 0;
+// }

--- a/lib/Opto/opto.h
+++ b/lib/Opto/opto.h
@@ -7,7 +7,7 @@ unsigned long get_delta_ticks(void); // return time between two obstructions in 
 float get_delta_time(void);
 
 // TODO: only for debug
-unsigned long overflow_ticks(char delta);
+// unsigned long overflow_ticks(char delta);
 
 // unsigned int get_n_average(int n);
 

--- a/src/main.c
+++ b/src/main.c
@@ -17,8 +17,6 @@ int main(void) {
   uart_init();   // open the communication to the microcontroller
   io_redirect(); // redirect input and output to the communication
 
-  TCCR1A = 0x00; // pure ticks counter
-  TCCR1B = 0xC5;
 
   DDRB &= ~0x01; // all pins act as input
   PORTB |= 0x01; // all pins in pull-down mode
@@ -37,13 +35,13 @@ int main(void) {
 
   opto_init();
 
-  unsigned long dtime;
+  float dtime;
 
   while (1) {
-    dtime = get_delta_ticks();
+    dtime = get_delta_time();
     if (dtime != 0)
-      printf("Time elapsed: %d\n", dtime);
-
+      printf("Time elapsed: %.2f\n", dtime);
+    
   }
 
   return 0;


### PR DESCRIPTION
Simplified the code to not deal with overflows that much. This is acceptable as an overflow only happens when the shaft were to stop for more than 4 seconds. At this point, the speed of the shaft is irrelevant. Additionally, the unsigned integers can handle subtracting a bigger number from a smaller, as it would only flow back.